### PR TITLE
Fix SDL dylib filename in configure for OSX

### DIFF
--- a/configure
+++ b/configure
@@ -1757,7 +1757,7 @@ SDL_CFLAGS=`$SDL_CONFIG --cflags`
 
 if test x`uname` = "xDarwin"; then
 	#SDL_LIBS="`$SDL_CONFIG --prefix`/lib/libSDLmain.a `$SDL_CONFIG --prefix`/lib/libSDL.dylib -Wl,-framework,Cocoa"
-  SDL_LIBS="$SDL_LIBS `$SDL_CONFIG --prefix`/lib/libSDL.dylib -Wl,-framework,Cocoa"
+  SDL_LIBS="$SDL_LIBS `$SDL_CONFIG --prefix`/lib/libSDL2.dylib -Wl,-framework,Cocoa"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ SDL_CFLAGS=`$SDL_CONFIG --cflags`
 
 if test x`uname` = "xDarwin"; then
 	#SDL_LIBS="`$SDL_CONFIG --prefix`/lib/libSDLmain.a `$SDL_CONFIG --prefix`/lib/libSDL.dylib -Wl,-framework,Cocoa"
-  SDL_LIBS="$SDL_LIBS `$SDL_CONFIG --prefix`/lib/libSDL.dylib -Wl,-framework,Cocoa"
+  SDL_LIBS="$SDL_LIBS `$SDL_CONFIG --prefix`/lib/libSDL2.dylib -Wl,-framework,Cocoa"
 fi
 
 AC_SUBST([SDL_CFLAGS])


### PR DESCRIPTION
This patch fixes a issue when building under OSX where is trying to local for the SDL1.2 libs. brew installed libs for sdl2 are now called libSDL2.dylib.

Pls. ignore the travis build output, I am setting that one up in another branch.
