### PR TITLE
Made Scancode derive Ord

### DIFF
--- a/Graphics/UI/SDL/Keysym.hsc
+++ b/Graphics/UI/SDL/Keysym.hsc
@@ -281,7 +281,7 @@ data Scancode
   | Sleep
   | App1
   | App2
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 instance Enum Scancode where
   toEnum #{const SDL_SCANCODE_A} = A


### PR DESCRIPTION
Made Scancode derive Ord, this make it possible to contain Scancode in datastructures like Data.Set which requires the type to derive Ord. Of course you can use StandaloneDeriving GHC extension and derive it yourself, but I think this is more portable.
