### PR TITLE
fixed casing in include

### DIFF
--- a/csrc/sdl_bits.c
+++ b/csrc/sdl_bits.c
@@ -1,4 +1,4 @@
-#include "SDL_Bits.h"
+#include "SDL_bits.h"
 
 int SDL_MostSignificantBitIndex32_Wrapper(Uint32 x)
 {


### PR DESCRIPTION
hsSDL2 won't compile on Ubuntu and Mint as SDL_Bits.h is cased SDL_bits.h (as all other includes).

This fixes the trivial build-problem.
