### PR TITLE
To store key presses in a Set, Keycode and Scancode must be instances of Ord

### DIFF
--- a/Graphics/UI/SDL/Keycode.hsc
+++ b/Graphics/UI/SDL/Keycode.hsc
@@ -237,7 +237,7 @@ data Keycode
   | DoubleQuote
   | RightParen
   | Underscore
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 instance Enum Keycode where
   toEnum #{const SDLK_a} = A

--- a/Graphics/UI/SDL/Keysym.hsc
+++ b/Graphics/UI/SDL/Keysym.hsc
@@ -281,7 +281,7 @@ data Scancode
   | Sleep
   | App1
   | App2
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 instance Enum Scancode where
   toEnum #{const SDL_SCANCODE_A} = A


### PR DESCRIPTION
In order to store key presses (Keysym) in a Set, they must be instances of Ord. It is possible to create an orphan instance of Keysym, but Keycode and Scancode are not exported from their modules. The only way to store Keysym in a Set is to make Keycode and Scancode instances of Ord as well.

In the [previous SDL bindings](http://hackage.haskell.org/package/SDL-0.6.5/docs/Graphics-UI-SDL-Keysym.html#t:SDLKey), SDLKey (known as Keycode and Scancode in 2.0) is an instance of Ord. Scancode is new to SDL 2.0 and is a counterpart to Keycode. Scancode corresponds to the physical location of the key on the keyboard, while Keycode corresponds to the symbol of the key.
